### PR TITLE
Create a copy of the Bytes passed to Resource::new_from_data() if it'…

### DIFF
--- a/Gir.toml
+++ b/Gir.toml
@@ -26,7 +26,6 @@ generate = [
     "Gio.MenuModel",
     "Gio.NotificationPriority",
     "Gio.Permission",
-    "Gio.Resource",
     "Gio.ResourceError",
     "Gio.ResourceLookupFlags",
     "Gio.SettingsBindFlags",
@@ -116,4 +115,13 @@ status = "generate"
     [[object.property]]
     name = "state"
     #value glib::VariantTy
+    ignore = true
+
+[[object]]
+name = "Gio.Resource"
+status = "generate"
+    [[object.function]]
+    name = "new_from_data"
+    # Requires special alignment, see
+    # https://bugzilla.gnome.org/show_bug.cgi?id=790030
     ignore = true

--- a/src/auto/resource.rs
+++ b/src/auto/resource.rs
@@ -23,14 +23,6 @@ glib_wrapper! {
 }
 
 impl Resource {
-    pub fn new_from_data(data: &glib::Bytes) -> Result<Resource, Error> {
-        unsafe {
-            let mut error = ptr::null_mut();
-            let ret = ffi::g_resource_new_from_data(data.to_glib_none().0, &mut error);
-            if error.is_null() { Ok(from_glib_full(ret)) } else { Err(from_glib_full(error)) }
-        }
-    }
-
     pub fn enumerate_children(&self, path: &str, lookup_flags: ResourceLookupFlags) -> Result<Vec<String>, Error> {
         unsafe {
             let mut error = ptr::null_mut();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,7 @@ macro_rules! callback_guard {
 }
 
 mod application;
+mod resource;
 
 pub use glib::{
     Error,

--- a/src/resource.rs
+++ b/src/resource.rs
@@ -1,0 +1,34 @@
+// Copyright 2017, The Gtk-rs Project Developers.
+// See the COPYRIGHT file at the top-level directory of this distribution.
+// Licensed under the MIT license, see the LICENSE file or <http://opensource.org/licenses/MIT>
+
+use Resource;
+use ffi;
+use glib_ffi;
+use glib;
+use glib::translate::*;
+use std::ptr;
+use std::mem;
+
+impl Resource {
+    pub fn new_from_data(data: &glib::Bytes) -> Result<Resource, glib::Error> {
+        unsafe {
+            let mut error = ptr::null_mut();
+
+            // Create a copy of data if it is not pointer-aligned
+            // https://bugzilla.gnome.org/show_bug.cgi?id=790030
+            let mut data = data.clone();
+            let data_ptr = glib_ffi::g_bytes_get_data(data.to_glib_none().0, ptr::null_mut());
+            if data_ptr as usize % mem::align_of::<*const u8>() != 0 {
+                data = glib::Bytes::from(&*data);
+            }
+
+            let ret = ffi::g_resource_new_from_data(data.to_glib_none().0, &mut error);
+            if error.is_null() {
+                Ok(from_glib_full(ret))
+            } else {
+                Err(from_glib_full(error))
+            }
+        }
+    }
+}


### PR DESCRIPTION
…s not pointer-aligned

See https://bugzilla.gnome.org/show_bug.cgi?id=790030

Fixes https://github.com/gtk-rs/glib/issues/242