### PR TITLE
Remove Cancellable::reset()

### DIFF
--- a/Gir.toml
+++ b/Gir.toml
@@ -16,7 +16,6 @@ generate = [
     "Gio.ApplicationFlags",
     "Gio.AskPasswordFlags",
     "Gio.BufferedOutputStream",
-    "Gio.Cancellable",
     "Gio.DataOutputStream",
     "Gio.DataStreamByteOrder",
     "Gio.DataStreamNewlineType",
@@ -135,6 +134,12 @@ status = "generate"
     name = "peek"
     #have almost same peek_buffer
     ignore = true
+
+[[object]]
+name = "Gio.Cancellable"
+status = "generate"
+trait = false
+concurrency = "send+sync"
 
 [[object]]
 name = "Gio.DataInputStream"

--- a/Gir.toml
+++ b/Gir.toml
@@ -140,6 +140,10 @@ name = "Gio.Cancellable"
 status = "generate"
 trait = false
 concurrency = "send+sync"
+    [[object.function]]
+    name = "reset"
+    #undefined behaviour
+    ignore = true
 
 [[object]]
 name = "Gio.DataInputStream"

--- a/src/auto/cancellable.rs
+++ b/src/auto/cancellable.rs
@@ -81,12 +81,6 @@ impl Cancellable {
         }
     }
 
-    pub fn reset(&self) {
-        unsafe {
-            ffi::g_cancellable_reset(self.to_glib_none().0);
-        }
-    }
-
     pub fn set_error_if_cancelled(&self) -> Result<(), Error> {
         unsafe {
             let mut error = ptr::null_mut();

--- a/src/auto/cancellable.rs
+++ b/src/auto/cancellable.rs
@@ -5,8 +5,6 @@
 use Error;
 use ffi;
 use glib;
-use glib::object::Downcast;
-use glib::object::IsA;
 use glib::signal::SignalHandlerId;
 use glib::signal::connect;
 use glib::translate::*;
@@ -33,9 +31,87 @@ impl Cancellable {
         }
     }
 
+    pub fn cancel(&self) {
+        unsafe {
+            ffi::g_cancellable_cancel(self.to_glib_none().0);
+        }
+    }
+
+    //pub fn connect<'a, P: Into<Option</*Unimplemented*/Fundamental: Pointer>>, Q: Into<Option<&'a /*Ignored*/glib::DestroyNotify>>>(&self, callback: /*Unknown conversion*//*Unimplemented*/Callback, data: P, data_destroy_func: Q) -> libc::c_ulong {
+    //    unsafe { TODO: call ffi::g_cancellable_connect() }
+    //}
+
+    pub fn disconnect(&self, handler_id: libc::c_ulong) {
+        unsafe {
+            ffi::g_cancellable_disconnect(self.to_glib_none().0, handler_id);
+        }
+    }
+
+    pub fn get_fd(&self) -> i32 {
+        unsafe {
+            ffi::g_cancellable_get_fd(self.to_glib_none().0)
+        }
+    }
+
+    pub fn is_cancelled(&self) -> bool {
+        unsafe {
+            from_glib(ffi::g_cancellable_is_cancelled(self.to_glib_none().0))
+        }
+    }
+
+    //pub fn make_pollfd(&self, pollfd: /*Ignored*/&mut glib::PollFD) -> bool {
+    //    unsafe { TODO: call ffi::g_cancellable_make_pollfd() }
+    //}
+
+    pub fn pop_current(&self) {
+        unsafe {
+            ffi::g_cancellable_pop_current(self.to_glib_none().0);
+        }
+    }
+
+    pub fn push_current(&self) {
+        unsafe {
+            ffi::g_cancellable_push_current(self.to_glib_none().0);
+        }
+    }
+
+    pub fn release_fd(&self) {
+        unsafe {
+            ffi::g_cancellable_release_fd(self.to_glib_none().0);
+        }
+    }
+
+    pub fn reset(&self) {
+        unsafe {
+            ffi::g_cancellable_reset(self.to_glib_none().0);
+        }
+    }
+
+    pub fn set_error_if_cancelled(&self) -> Result<(), Error> {
+        unsafe {
+            let mut error = ptr::null_mut();
+            let _ = ffi::g_cancellable_set_error_if_cancelled(self.to_glib_none().0, &mut error);
+            if error.is_null() { Ok(()) } else { Err(from_glib_full(error)) }
+        }
+    }
+
+    pub fn source_new(&self) -> Option<glib::Source> {
+        unsafe {
+            from_glib_full(ffi::g_cancellable_source_new(self.to_glib_none().0))
+        }
+    }
+
     pub fn get_current() -> Option<Cancellable> {
         unsafe {
             from_glib_none(ffi::g_cancellable_get_current())
+        }
+    }
+
+    pub fn connect_cancelled<F: Fn(&Cancellable) + Send + Sync + 'static>(&self, f: F) -> SignalHandlerId {
+        unsafe {
+            let f: Box_<Box_<Fn(&Cancellable) + Send + Sync + 'static>> = Box_::new(Box_::new(f));
+            connect(self.to_glib_none().0, "cancelled",
+                transmute(cancelled_trampoline as usize), Box_::into_raw(f) as *mut _)
         }
     }
 }
@@ -46,117 +122,11 @@ impl Default for Cancellable {
     }
 }
 
-pub trait CancellableExt {
-    fn cancel(&self);
+unsafe impl Send for Cancellable {}
+unsafe impl Sync for Cancellable {}
 
-    //fn connect<'a, P: Into<Option</*Unimplemented*/Fundamental: Pointer>>, Q: Into<Option<&'a /*Ignored*/glib::DestroyNotify>>>(&self, callback: /*Unknown conversion*//*Unimplemented*/Callback, data: P, data_destroy_func: Q) -> libc::c_ulong;
-
-    fn disconnect(&self, handler_id: libc::c_ulong);
-
-    fn get_fd(&self) -> i32;
-
-    fn is_cancelled(&self) -> bool;
-
-    //fn make_pollfd(&self, pollfd: /*Ignored*/&mut glib::PollFD) -> bool;
-
-    fn pop_current(&self);
-
-    fn push_current(&self);
-
-    fn release_fd(&self);
-
-    fn reset(&self);
-
-    fn set_error_if_cancelled(&self) -> Result<(), Error>;
-
-    fn source_new(&self) -> Option<glib::Source>;
-
-    fn connect_cancelled<F: Fn(&Self) + 'static>(&self, f: F) -> SignalHandlerId;
-}
-
-impl<O: IsA<Cancellable> + IsA<glib::object::Object>> CancellableExt for O {
-    fn cancel(&self) {
-        unsafe {
-            ffi::g_cancellable_cancel(self.to_glib_none().0);
-        }
-    }
-
-    //fn connect<'a, P: Into<Option</*Unimplemented*/Fundamental: Pointer>>, Q: Into<Option<&'a /*Ignored*/glib::DestroyNotify>>>(&self, callback: /*Unknown conversion*//*Unimplemented*/Callback, data: P, data_destroy_func: Q) -> libc::c_ulong {
-    //    unsafe { TODO: call ffi::g_cancellable_connect() }
-    //}
-
-    fn disconnect(&self, handler_id: libc::c_ulong) {
-        unsafe {
-            ffi::g_cancellable_disconnect(self.to_glib_none().0, handler_id);
-        }
-    }
-
-    fn get_fd(&self) -> i32 {
-        unsafe {
-            ffi::g_cancellable_get_fd(self.to_glib_none().0)
-        }
-    }
-
-    fn is_cancelled(&self) -> bool {
-        unsafe {
-            from_glib(ffi::g_cancellable_is_cancelled(self.to_glib_none().0))
-        }
-    }
-
-    //fn make_pollfd(&self, pollfd: /*Ignored*/&mut glib::PollFD) -> bool {
-    //    unsafe { TODO: call ffi::g_cancellable_make_pollfd() }
-    //}
-
-    fn pop_current(&self) {
-        unsafe {
-            ffi::g_cancellable_pop_current(self.to_glib_none().0);
-        }
-    }
-
-    fn push_current(&self) {
-        unsafe {
-            ffi::g_cancellable_push_current(self.to_glib_none().0);
-        }
-    }
-
-    fn release_fd(&self) {
-        unsafe {
-            ffi::g_cancellable_release_fd(self.to_glib_none().0);
-        }
-    }
-
-    fn reset(&self) {
-        unsafe {
-            ffi::g_cancellable_reset(self.to_glib_none().0);
-        }
-    }
-
-    fn set_error_if_cancelled(&self) -> Result<(), Error> {
-        unsafe {
-            let mut error = ptr::null_mut();
-            let _ = ffi::g_cancellable_set_error_if_cancelled(self.to_glib_none().0, &mut error);
-            if error.is_null() { Ok(()) } else { Err(from_glib_full(error)) }
-        }
-    }
-
-    fn source_new(&self) -> Option<glib::Source> {
-        unsafe {
-            from_glib_full(ffi::g_cancellable_source_new(self.to_glib_none().0))
-        }
-    }
-
-    fn connect_cancelled<F: Fn(&Self) + 'static>(&self, f: F) -> SignalHandlerId {
-        unsafe {
-            let f: Box_<Box_<Fn(&Self) + 'static>> = Box_::new(Box_::new(f));
-            connect(self.to_glib_none().0, "cancelled",
-                transmute(cancelled_trampoline::<Self> as usize), Box_::into_raw(f) as *mut _)
-        }
-    }
-}
-
-unsafe extern "C" fn cancelled_trampoline<P>(this: *mut ffi::GCancellable, f: glib_ffi::gpointer)
-where P: IsA<Cancellable> {
+unsafe extern "C" fn cancelled_trampoline(this: *mut ffi::GCancellable, f: glib_ffi::gpointer) {
     callback_guard!();
-    let f: &&(Fn(&P) + 'static) = transmute(f);
-    f(&Cancellable::from_glib_borrow(this).downcast_unchecked())
+    let f: &&(Fn(&Cancellable) + Send + Sync + 'static) = transmute(f);
+    f(&from_glib_borrow(this))
 }

--- a/src/auto/mod.rs
+++ b/src/auto/mod.rs
@@ -36,7 +36,6 @@ pub use self::buffered_output_stream::BufferedOutputStreamExt;
 
 mod cancellable;
 pub use self::cancellable::Cancellable;
-pub use self::cancellable::CancellableExt;
 
 mod data_input_stream;
 pub use self::data_input_stream::DataInputStream;
@@ -439,7 +438,6 @@ pub mod traits {
     pub use super::ApplicationExt;
     pub use super::BufferedInputStreamExt;
     pub use super::BufferedOutputStreamExt;
-    pub use super::CancellableExt;
     pub use super::DataInputStreamExt;
     pub use super::DataOutputStreamExt;
     pub use super::FileExt;


### PR DESCRIPTION
commit c48c9a8c7a577244a051b0a580fb4681a0435c59 (HEAD -> cancellable-no-reset)
Author: Sebastian Dröge <sebastian@centricular.com>
Date:   Mon Apr 9 18:19:26 2018 +0200

    Remove Cancellable::reset()
    
    It can easily cause undefined behaviour, see
    https://github.com/gtk-rs/gio/pull/102#issuecomment-379690071
