### PR TITLE
Don't require a mutable main context in the futures/MemoryInputStream…

### DIFF
--- a/src/memory_input_stream.rs
+++ b/src/memory_input_stream.rs
@@ -59,7 +59,7 @@ mod tests {
     fn read_async_future() {
         use futures_util::FutureExt;
 
-        let mut c = glib::MainContext::new();
+        let c = glib::MainContext::new();
 
         let buf = vec![0; 10];
         let b = glib::Bytes::from_owned(vec![1, 2, 3]);


### PR DESCRIPTION
… test


Depends on https://github.com/gtk-rs/glib/pull/328