### PR TITLE
Fix OutputStream::write_all()

### DIFF
--- a/Gir.toml
+++ b/Gir.toml
@@ -490,6 +490,10 @@ status = "generate"
     name = "write_all_async"
     #AsRef<u8>
     ignore = true
+    [[object.function]]
+    name = "write_all"
+    # special return value
+    ignore = true
 
 [[object]]
 name = "Gio.PollableInputStream"

--- a/src/auto/output_stream.rs
+++ b/src/auto/output_stream.rs
@@ -67,8 +67,6 @@ pub trait OutputStreamExt: Sized {
 
     fn write<'a, P: Into<Option<&'a Cancellable>>>(&self, buffer: &[u8], cancellable: P) -> Result<isize, Error>;
 
-    fn write_all<'a, P: Into<Option<&'a Cancellable>>>(&self, buffer: &[u8], cancellable: P) -> Result<usize, Error>;
-
     fn write_bytes<'a, P: Into<Option<&'a Cancellable>>>(&self, bytes: &glib::Bytes, cancellable: P) -> Result<isize, Error>;
 
     fn write_bytes_async<'a, P: Into<Option<&'a Cancellable>>, Q: FnOnce(Result<isize, Error>) + Send + 'static>(&self, bytes: &glib::Bytes, io_priority: glib::Priority, cancellable: P, callback: Q);
@@ -284,18 +282,6 @@ impl<O: IsA<OutputStream> + IsA<glib::object::Object> + Clone + 'static> OutputS
             let mut error = ptr::null_mut();
             let ret = ffi::g_output_stream_write(self.to_glib_none().0, buffer.to_glib_none().0, count, cancellable.0, &mut error);
             if error.is_null() { Ok(ret) } else { Err(from_glib_full(error)) }
-        }
-    }
-
-    fn write_all<'a, P: Into<Option<&'a Cancellable>>>(&self, buffer: &[u8], cancellable: P) -> Result<usize, Error> {
-        let cancellable = cancellable.into();
-        let cancellable = cancellable.to_glib_none();
-        let count = buffer.len() as usize;
-        unsafe {
-            let mut bytes_written = mem::uninitialized();
-            let mut error = ptr::null_mut();
-            let _ = ffi::g_output_stream_write_all(self.to_glib_none().0, buffer.to_glib_none().0, count, &mut bytes_written, cancellable.0, &mut error);
-            if error.is_null() { Ok(bytes_written) } else { Err(from_glib_full(error)) }
         }
     }
 

--- a/src/input_stream.rs
+++ b/src/input_stream.rs
@@ -75,7 +75,7 @@ impl<O: IsA<InputStream> + IsA<glib::Object> + Clone + 'static> InputStreamExtMa
             } else if bytes_read != 0 {
                 Ok((bytes_read, Some(from_glib_full(error))))
             } else {
-                Err( from_glib_full(error))
+                Err(from_glib_full(error))
             }
         }
     }


### PR DESCRIPTION
It can return an error *and* can have bytes written out. We have to
return the written bytes in any case, and did so already for the async
variants and InputStream::read_all().

Fixes https://github.com/gtk-rs/gio/issues/149