### PR TITLE
Implement trait Default for ApplicationFlags

### DIFF
--- a/src/flags.rs
+++ b/src/flags.rs
@@ -1,0 +1,11 @@
+// Copyright 2018, The Gtk-rs Project Developers.
+// See the COPYRIGHT file at the top-level directory of this distribution.
+// Licensed under the MIT license, see the LICENSE file or <http://opensource.org/licenses/MIT>
+
+use ApplicationFlags;
+
+impl Default for ApplicationFlags {
+    fn default() -> ApplicationFlags {
+        ApplicationFlags::empty()
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,6 +32,7 @@ mod converter;
 #[cfg(any(not(windows), feature = "dox"))]
 mod desktop_app_info;
 mod file;
+mod flags;
 mod input_stream;
 #[cfg(any(feature = "v2_44", feature = "dox"))]
 mod list_store;


### PR DESCRIPTION
See https://github.com/gtk-rs/examples/pull/199#issuecomment-432971480,
add "magic " to creating application
```diff
--- a/src/bin/basic.rs
+++ b/src/bin/basic.rs
@@ -34,7 +36,7 @@ fn build_ui(application: &gtk::Application) {
 
 fn main() {
     let application = gtk::Application::new("com.github.gtk-rs.examples.basic",
-                                            gio::ApplicationFlags::empty())
+                                            Default::default())
                                        .expect("Initialization failed...");
 
     application.connect_activate(|app| {
```
As it don't help removing `use gio::prelude::*;` completely
as at minimum two `use gio::ApplicationExtXXX;` needed,
I not sure now that this really needed.


cc @GuillaumeGomez, @sdroege 