### PR TITLE
Add impls for new std::io::{Read,Write} structs

### DIFF
--- a/src/input_stream.rs
+++ b/src/input_stream.rs
@@ -210,6 +210,7 @@ impl<O: IsA<InputStream> + IsA<glib::Object> + Clone + 'static> InputStreamExtMa
     }
 }
 
+#[derive(Debug, PartialEq, Eq, Hash, Clone)]
 pub struct InputStreamRead<T: InputStreamExtManual>(T);
 
 impl <T: InputStreamExtManual> InputStreamRead<T> {

--- a/src/input_stream.rs
+++ b/src/input_stream.rs
@@ -217,6 +217,10 @@ impl <T: InputStreamExtManual> InputStreamRead<T> {
     pub fn into_input_stream(self) -> T {
         self.0
     }
+
+    pub fn input_stream(&self) -> &T {
+        &self.0
+    }
 }
 
 impl <T: InputStreamExtManual> io::Read for InputStreamRead<T> {

--- a/src/output_stream.rs
+++ b/src/output_stream.rs
@@ -193,6 +193,10 @@ impl <T: OutputStreamExt> OutputStreamWrite<T> {
     pub fn into_output_stream(self) -> T {
         self.0
     }
+
+    pub fn output_stream(&self) -> &T {
+        &self.0
+    }
 }
 
 impl <T: OutputStreamExt> io::Write for OutputStreamWrite<T> {

--- a/src/output_stream.rs
+++ b/src/output_stream.rs
@@ -186,6 +186,7 @@ impl<O: IsA<OutputStream> + IsA<glib::Object> + Clone + 'static> OutputStreamExt
     }
 }
 
+#[derive(Debug, PartialEq, Eq, Hash, Clone)]
 pub struct OutputStreamWrite<T: OutputStreamExt>(T);
 
 impl <T: OutputStreamExt> OutputStreamWrite<T> {

--- a/tests/std_io_copy.rs
+++ b/tests/std_io_copy.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "v2_36")]
+
 extern crate glib;
 extern crate gio;
 


### PR DESCRIPTION
I added impls for Debug, PartialEq, Eq, Hash, Clone to the new helper structs.

@sdroege There already are `into_input_stream` and `into_output_stream` methods on the structs to turn them back into the gio types. Or did you mean something else?