### PR TITLE
Fix socket.rs build with --features dox

### DIFF
--- a/src/socket.rs
+++ b/src/socket.rs
@@ -302,7 +302,7 @@ pub trait AsRawFd {
 }
 
 #[cfg(all(not(unix), feature = "dox"))]
-pub struct RawFd(c_int);
+pub type RawFd = c_int;
 
 #[cfg(all(not(windows), feature = "dox"))]
 pub trait IntoRawSocket {
@@ -320,4 +320,4 @@ pub trait AsRawSocket {
 }
 
 #[cfg(all(not(windows), feature = "dox"))]
-pub struct RawSocket(*mut c_void);
+pub type RawSocket = *mut c_void;


### PR DESCRIPTION
error[E0605]: non-primitive cast: `i32` as `socket::RawSocket`
  --> src/socket.rs:64:13
   |
64 |             ffi::g_socket_get_fd(self.to_glib_none().0) as _
   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: an `as` expression can only be used to convert between primitive types. Consider using the `From` trait

----

See https://github.com/gtk-rs/gio/pull/175#issuecomment-447677702