### PR TITLE
Fix generating docs for UnixXXXStream

### DIFF
--- a/src/unix_input_stream.rs
+++ b/src/unix_input_stream.rs
@@ -7,7 +7,11 @@ use glib::translate::*;
 use InputStream;
 use UnixInputStream;
 
+#[cfg(unix)]
 use std::os::unix::io::{RawFd, AsRawFd, IntoRawFd, FromRawFd};
+
+#[cfg(all(not(unix), feature = "dox"))]
+use ::socket::{RawFd, AsRawFd, IntoRawFd, FromRawFd};
 
 impl UnixInputStream {
 

--- a/src/unix_output_stream.rs
+++ b/src/unix_output_stream.rs
@@ -7,7 +7,11 @@ use glib::translate::*;
 use OutputStream;
 use UnixOutputStream;
 
+#[cfg(unix)]
 use std::os::unix::io::{RawFd, AsRawFd, IntoRawFd, FromRawFd};
+
+#[cfg(all(not(unix), feature = "dox"))]
+use ::socket::{RawFd, AsRawFd, IntoRawFd, FromRawFd};
 
 impl UnixOutputStream {
 


### PR DESCRIPTION
#208 broke apveyor doc test
https://ci.appveyor.com/project/GuillaumeGomez/gtk/builds/24553406/job/nq5dssq5o0dhxnj6#L209
```
 --> C:\Users\appveyor\.cargo\git\checkouts\gio-a4b825b310a073b9\10df4f6\src\unix_input_stream.rs:10:14
   |
10 | use std::os::unix::io::{RawFd, AsRawFd, IntoRawFd, FromRawFd};
   |              ^^^^ could not find `unix` in `os`
```

cc @GuillaumeGomez, @sdroege 