### PR TITLE
Do not generate Gio.DesktopAppInfo on macos to avoid link failure

### DIFF
--- a/Gir.toml
+++ b/Gir.toml
@@ -329,7 +329,7 @@ status = "generate"
 [[object]]
 name = "Gio.DesktopAppInfo"
 status = "generate"
-cfg_condition = "not(windows)"
+cfg_condition = "all(not(windows),not(target_os = "macos"))"
     [[object.function]]
     name = "search"
     # returns vec of string


### PR DESCRIPTION
DesktopAppInfo functions are not exists on macos, see https://github.com/gtk-rs/gio/issues/272