### PR TITLE
Use mem::ManuallyDrop instead of mem::forget() everywhere

### DIFF
--- a/src/subclass/input_stream.rs
+++ b/src/subclass/input_stream.rs
@@ -194,9 +194,9 @@ where
             assert!(res <= count);
             res as isize
         }
-        Err(mut e) => {
+        Err(e) => {
+            let mut e = mem::ManuallyDrop::new(e);
             *err = e.to_glib_none_mut().0;
-            mem::forget(e);
             -1
         }
     }
@@ -221,9 +221,9 @@ where
             .as_ref(),
     ) {
         Ok(_) => glib_sys::GTRUE,
-        Err(mut e) => {
+        Err(e) => {
+            let mut e = mem::ManuallyDrop::new(e);
             *err = e.to_glib_none_mut().0;
-            mem::forget(e);
             glib_sys::GFALSE
         }
     }
@@ -258,9 +258,9 @@ where
             assert!(res <= count);
             res as isize
         }
-        Err(mut e) => {
+        Err(e) => {
+            let mut e = mem::ManuallyDrop::new(e);
             *err = e.to_glib_none_mut().0;
-            mem::forget(e);
             -1
         }
     }

--- a/src/subclass/io_stream.rs
+++ b/src/subclass/io_stream.rs
@@ -205,9 +205,9 @@ where
             .as_ref(),
     ) {
         Ok(_) => glib_sys::GTRUE,
-        Err(mut e) => {
+        Err(e) => {
+            let mut e = mem::ManuallyDrop::new(e);
             *err = e.to_glib_none_mut().0;
-            mem::forget(e);
             glib_sys::GFALSE
         }
     }

--- a/src/subclass/output_stream.rs
+++ b/src/subclass/output_stream.rs
@@ -235,9 +235,9 @@ where
             assert!(res <= count);
             res as isize
         }
-        Err(mut e) => {
+        Err(e) => {
+            let mut e = mem::ManuallyDrop::new(e);
             *err = e.to_glib_none_mut().0;
-            mem::forget(e);
             -1
         }
     }
@@ -262,9 +262,9 @@ where
             .as_ref(),
     ) {
         Ok(_) => glib_sys::GTRUE,
-        Err(mut e) => {
+        Err(e) => {
+            let mut e = mem::ManuallyDrop::new(e);
             *err = e.to_glib_none_mut().0;
-            mem::forget(e);
             glib_sys::GFALSE
         }
     }
@@ -289,9 +289,9 @@ where
             .as_ref(),
     ) {
         Ok(_) => glib_sys::GTRUE,
-        Err(mut e) => {
+        Err(e) => {
+            let mut e = mem::ManuallyDrop::new(e);
             *err = e.to_glib_none_mut().0;
-            mem::forget(e);
             glib_sys::GFALSE
         }
     }
@@ -324,9 +324,9 @@ where
             assert!(res <= isize::MAX as usize);
             res as isize
         }
-        Err(mut e) => {
+        Err(e) => {
+            let mut e = mem::ManuallyDrop::new(e);
             *err = e.to_glib_none_mut().0;
-            mem::forget(e);
             -1
         }
     }

--- a/src/subclass/seekable.rs
+++ b/src/subclass/seekable.rs
@@ -94,9 +94,9 @@ where
             .as_ref(),
     ) {
         Ok(()) => glib_sys::GTRUE,
-        Err(mut e) => {
+        Err(e) => {
+            let mut e = mem::ManuallyDrop::new(e);
             *err = e.to_glib_none_mut().0;
-            mem::forget(e);
             glib_sys::GFALSE
         }
     }
@@ -134,9 +134,9 @@ where
             .as_ref(),
     ) {
         Ok(()) => glib_sys::GTRUE,
-        Err(mut e) => {
+        Err(e) => {
+            let mut e = mem::ManuallyDrop::new(e);
             *err = e.to_glib_none_mut().0;
-            mem::forget(e);
             glib_sys::GFALSE
         }
     }


### PR DESCRIPTION
It makes the intentions clearer and potentially results in simpler
assembly, at least in debug builds.