### PR TITLE
Add callback check

### DIFF
--- a/src/cancellable.rs
+++ b/src/cancellable.rs
@@ -1,0 +1,12 @@
+// Copyright 2013-2020, The Gtk-rs Project Developers.
+// See the COPYRIGHT file at the top-level directory of this distribution.
+// Licensed under the MIT license, see the LICENSE file or <http://opensource.org/licenses/MIT>
+
+use crate::CancellableExt;
+
+#[test]
+fn check_callback() {
+    let c = crate::Cancellable::new();
+    c.connect_cancelled(|_| {});
+    c.cancel(); // if it doesn't crash at this point, then we're good to go!
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,8 @@ extern crate futures_util;
 
 mod app_info;
 mod application;
+#[cfg(test)]
+mod cancellable;
 mod converter;
 mod data_input_stream;
 #[cfg(any(all(not(windows), not(target_os = "macos")), feature = "dox"))]


### PR DESCRIPTION
This PR is meant to fail until we put back the old function pointer cast system. It'll be used to enforce that at least this cast will be correct.

cc @EPashkin @sdroege 