### PR TITLE
Support various things which needed glib::VariantDict

### DIFF
--- a/Gir.toml
+++ b/Gir.toml
@@ -154,6 +154,7 @@ manual = [
     "GLib.SpawnFlags",
     "GLib.TimeVal",
     "GLib.Variant",
+    "GLib.VariantDict",
     "GLib.VariantType",
     "GObject.Object",
     "GObject.Value",

--- a/src/auto/application_command_line.rs
+++ b/src/auto/application_command_line.rs
@@ -42,7 +42,7 @@ pub trait ApplicationCommandLineExt: 'static {
 
     fn get_is_remote(&self) -> bool;
 
-    //fn get_options_dict(&self) -> /*Ignored*/Option<glib::VariantDict>;
+    fn get_options_dict(&self) -> Option<glib::VariantDict>;
 
     fn get_platform_data(&self) -> Option<glib::Variant>;
 
@@ -113,9 +113,13 @@ impl<O: IsA<ApplicationCommandLine>> ApplicationCommandLineExt for O {
         }
     }
 
-    //fn get_options_dict(&self) -> /*Ignored*/Option<glib::VariantDict> {
-    //    unsafe { TODO: call gio_sys:g_application_command_line_get_options_dict() }
-    //}
+    fn get_options_dict(&self) -> Option<glib::VariantDict> {
+        unsafe {
+            from_glib_none(gio_sys::g_application_command_line_get_options_dict(
+                self.as_ref().to_glib_none().0,
+            ))
+        }
+    }
 
     fn get_platform_data(&self) -> Option<glib::Variant> {
         unsafe {


### PR DESCRIPTION
In https://github.com/gtk-rs/glib/pull/634 we added glib::VariantDict so this PR turns on support for it.

This ought to fix #291 which is on the current release roadmap (https://github.com/gtk-rs/release/issues/115)