### PR TITLE
Increase reference count of the stored streams in the IOStream when s…

### DIFF
--- a/src/subclass/io_stream.rs
+++ b/src/subclass/io_stream.rs
@@ -142,7 +142,7 @@ where
     gobject_sys::g_object_set_qdata_full(
         ptr as *mut _,
         INPUT_STREAM_QUARK.to_glib(),
-        ret.as_ptr() as *mut _,
+        gobject_sys::g_object_ref(ret.as_ptr() as *mut _) as *mut _,
         Some(unref),
     );
 
@@ -179,7 +179,7 @@ where
     gobject_sys::g_object_set_qdata_full(
         ptr as *mut _,
         OUTPUT_STREAM_QUARK.to_glib(),
-        ret.as_ptr() as *mut _,
+        gobject_sys::g_object_ref(ret.as_ptr() as *mut _) as *mut _,
         Some(unref),
     );
 


### PR DESCRIPTION
…ubclassing

We return it transfer-none to the caller so our reference would be
dropped at the end of the scope, and then a second time when the
IOStream is finalized. As such we have to increase the reference count
once to prevent a double-free.

----

CC @GuillaumeGomez @EPashkin 